### PR TITLE
Stored object coordinates and blocked collision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+Labyrinth.Console/Properties/launchSettings.json

--- a/.gitignore
+++ b/.gitignore
@@ -348,4 +348,3 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
-Labyrinth.Console/Properties/launchSettings.json

--- a/Labyrinth.Console/Program.cs
+++ b/Labyrinth.Console/Program.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Text;
 
 Dictionary<ObstacleEdges, char> edgeSymbolsMap = ConstructObstacleEdgesMap();
+HashSet<Coordinates> BannedCoordinates = new HashSet<Coordinates>();
 
 // 1. Fix the game screen.
 // 1.1. Add check for the resolution of the screen. Or dynamicaly adjust the settings.
@@ -26,6 +27,8 @@ for (int i = 0; i < 20; i++)
     Coordinates currentObstacleCoordinates = new Coordinates { X = randomObstacleX, Y = randomObstacleY };
     Obstacle currentObstacle = new Obstacle(currentObstacleCoordinates, randomObstacleEdges);
 
+    BannedCoordinates.Add(currentObstacleCoordinates);
+
     RenderObstacle(currentObstacle);
 }
 
@@ -38,27 +41,58 @@ while (pressedKey.Key != ConsoleKey.Escape)
     {
         ClearPlayer();
         playerCoordinates = playerCoordinates with { Y = playerCoordinates.Y - 1 };
-        RenderPlayer();
+        if(!BannedCoordinates.Contains(playerCoordinates))
+        {
+            RenderPlayer();
+        }
+        else
+        {
+            playerCoordinates = playerCoordinates with { Y = playerCoordinates.Y + 1 };
+            RenderPlayer();
+        }
     }
     else if (pressedKey.Key == ConsoleKey.RightArrow && playerCoordinates.X + 1 < playgroundWidth)
     {
         ClearPlayer();
         playerCoordinates = playerCoordinates with { X = playerCoordinates.X + 1 };
-        RenderPlayer();
+        if(!BannedCoordinates.Contains(playerCoordinates))
+        {
+            RenderPlayer();
+        }
+        else
+        {
+            playerCoordinates = playerCoordinates with { X = playerCoordinates.X - 1 };
+            RenderPlayer();
+        }
     }
     else if (pressedKey.Key == ConsoleKey.DownArrow && playerCoordinates.Y + 1 < playgroundHeight)
     {
         ClearPlayer();
         playerCoordinates = playerCoordinates with { Y = playerCoordinates.Y + 1 };
-        RenderPlayer();
+        if (!BannedCoordinates.Contains(playerCoordinates))
+        {
+            RenderPlayer();
+        }
+        else
+        {
+            playerCoordinates = playerCoordinates with { Y = playerCoordinates.Y - 1 };
+            RenderPlayer();
+        }
     }
     else if (pressedKey.Key == ConsoleKey.LeftArrow && playerCoordinates.X > 0)
     {
         ClearPlayer();
         playerCoordinates = playerCoordinates with { X = playerCoordinates.X - 1 };
-        RenderPlayer();
+        if (!BannedCoordinates.Contains(playerCoordinates))
+        {
+            RenderPlayer();
+        }
+        else
+        {
+            playerCoordinates = playerCoordinates with { X = playerCoordinates.X + 1 };
+            RenderPlayer();
+        }
     }
-
 
     pressedKey = Console.ReadKey(intercept: true);
 }
@@ -104,7 +138,6 @@ static Dictionary<ObstacleEdges, char> ConstructObstacleEdgesMap()
     edgeSymbolsMap[ObstacleEdges.Left] = '═';
     edgeSymbolsMap[ObstacleEdges.Right] = '═';
     edgeSymbolsMap[ObstacleEdges.Left | ObstacleEdges.Right] = '═';
-
     edgeSymbolsMap[ObstacleEdges.Top | ObstacleEdges.Right] = '╚';
     edgeSymbolsMap[ObstacleEdges.Bottom | ObstacleEdges.Right] = '╔';
     edgeSymbolsMap[ObstacleEdges.Bottom | ObstacleEdges.Left] = '╗';

--- a/Labyrinth.Console/Program.cs
+++ b/Labyrinth.Console/Program.cs
@@ -37,62 +37,27 @@ ConsoleKeyInfo pressedKey = Console.ReadKey(intercept: true);
 while (pressedKey.Key != ConsoleKey.Escape)
 {
     // 4. Configure this - ask the user for its preferrences.
-    if (pressedKey.Key == ConsoleKey.UpArrow && playerCoordinates.Y > systemRows)
+    Coordinates newPlayerCoordinates;
+    if (pressedKey.Key == ConsoleKey.UpArrow)
+        newPlayerCoordinates = playerCoordinates with { Y = playerCoordinates.Y - 1 };
+    else if (pressedKey.Key == ConsoleKey.RightArrow)
+        newPlayerCoordinates = playerCoordinates with { X = playerCoordinates.X + 1 };
+    else if (pressedKey.Key == ConsoleKey.DownArrow)
+        newPlayerCoordinates = playerCoordinates with { Y = playerCoordinates.Y + 1 };
+    else if (pressedKey.Key == ConsoleKey.LeftArrow)
+        newPlayerCoordinates = playerCoordinates with { X = playerCoordinates.X - 1 };
+    else newPlayerCoordinates = playerCoordinates;
+
+    if (newPlayerCoordinates.X >= 0 && newPlayerCoordinates.Y >= systemRows && newPlayerCoordinates.X < playgroundWidth && newPlayerCoordinates.Y < playgroundHeight && !bannedCoordinates.Contains(newPlayerCoordinates))
     {
         ClearPlayer();
-        playerCoordinates = playerCoordinates with { Y = playerCoordinates.Y - 1 };
-        if (obstacleCollisionIsPossible(bannedCoordinates, playerCoordinates))
-        {
-            playerCoordinates = playerCoordinates with { Y = playerCoordinates.Y + 1 };
-            RenderPlayer();
-        }
-        else RenderPlayer();
-    }
-    else if (pressedKey.Key == ConsoleKey.RightArrow && playerCoordinates.X + 1 < playgroundWidth)
-    {
-        ClearPlayer();
-        playerCoordinates = playerCoordinates with { X = playerCoordinates.X + 1 };
-        if(obstacleCollisionIsPossible(bannedCoordinates, playerCoordinates))
-        {
-            playerCoordinates = playerCoordinates with { X = playerCoordinates.X - 1 };
-            RenderPlayer();
-        }
-        else RenderPlayer();
-    }
-    else if (pressedKey.Key == ConsoleKey.DownArrow && playerCoordinates.Y + 1 < playgroundHeight)
-    {
-        ClearPlayer();
-        playerCoordinates = playerCoordinates with { Y = playerCoordinates.Y + 1 };
-        if (obstacleCollisionIsPossible(bannedCoordinates, playerCoordinates))
-        {
-            playerCoordinates = playerCoordinates with { Y = playerCoordinates.Y - 1 };
-            RenderPlayer();
-        }
-        else RenderPlayer();
-    }
-    else if (pressedKey.Key == ConsoleKey.LeftArrow && playerCoordinates.X > 0)
-    {
-        ClearPlayer();
-        playerCoordinates = playerCoordinates with { X = playerCoordinates.X - 1 };
-        if (obstacleCollisionIsPossible(bannedCoordinates, playerCoordinates))
-        {
-            playerCoordinates = playerCoordinates with { X = playerCoordinates.X + 1 };
-            RenderPlayer();
-        }
-        else RenderPlayer();
+        playerCoordinates = newPlayerCoordinates;
+        RenderPlayer();
     }
 
     pressedKey = Console.ReadKey(intercept: true);
 }
 
-bool obstacleCollisionIsPossible(HashSet<Coordinates> obstacleCoords, Coordinates playerCoords)
-{
-    if (obstacleCoords.Contains(playerCoords))
-    {
-        return true;
-    }
-    return false;
-}
 void ClearPlayer()
 {
     Console.SetCursorPosition(playerCoordinates.X, playerCoordinates.Y);

--- a/Labyrinth.Console/Program.cs
+++ b/Labyrinth.Console/Program.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Text;
 
 Dictionary<ObstacleEdges, char> edgeSymbolsMap = ConstructObstacleEdgesMap();
-HashSet<Coordinates> BannedCoordinates = new HashSet<Coordinates>();
+HashSet<Coordinates> bannedCoordinates = new HashSet<Coordinates>();
 
 // 1. Fix the game screen.
 // 1.1. Add check for the resolution of the screen. Or dynamicaly adjust the settings.
@@ -27,7 +27,7 @@ for (int i = 0; i < 20; i++)
     Coordinates currentObstacleCoordinates = new Coordinates { X = randomObstacleX, Y = randomObstacleY };
     Obstacle currentObstacle = new Obstacle(currentObstacleCoordinates, randomObstacleEdges);
 
-    BannedCoordinates.Add(currentObstacleCoordinates);
+    bannedCoordinates.Add(currentObstacleCoordinates);
 
     RenderObstacle(currentObstacle);
 }
@@ -41,62 +41,58 @@ while (pressedKey.Key != ConsoleKey.Escape)
     {
         ClearPlayer();
         playerCoordinates = playerCoordinates with { Y = playerCoordinates.Y - 1 };
-        if(!BannedCoordinates.Contains(playerCoordinates))
-        {
-            RenderPlayer();
-        }
-        else
+        if (obstacleCollisionIsPossible(bannedCoordinates, playerCoordinates))
         {
             playerCoordinates = playerCoordinates with { Y = playerCoordinates.Y + 1 };
             RenderPlayer();
         }
+        else RenderPlayer();
     }
     else if (pressedKey.Key == ConsoleKey.RightArrow && playerCoordinates.X + 1 < playgroundWidth)
     {
         ClearPlayer();
         playerCoordinates = playerCoordinates with { X = playerCoordinates.X + 1 };
-        if(!BannedCoordinates.Contains(playerCoordinates))
-        {
-            RenderPlayer();
-        }
-        else
+        if(obstacleCollisionIsPossible(bannedCoordinates, playerCoordinates))
         {
             playerCoordinates = playerCoordinates with { X = playerCoordinates.X - 1 };
             RenderPlayer();
         }
+        else RenderPlayer();
     }
     else if (pressedKey.Key == ConsoleKey.DownArrow && playerCoordinates.Y + 1 < playgroundHeight)
     {
         ClearPlayer();
         playerCoordinates = playerCoordinates with { Y = playerCoordinates.Y + 1 };
-        if (!BannedCoordinates.Contains(playerCoordinates))
-        {
-            RenderPlayer();
-        }
-        else
+        if (obstacleCollisionIsPossible(bannedCoordinates, playerCoordinates))
         {
             playerCoordinates = playerCoordinates with { Y = playerCoordinates.Y - 1 };
             RenderPlayer();
         }
+        else RenderPlayer();
     }
     else if (pressedKey.Key == ConsoleKey.LeftArrow && playerCoordinates.X > 0)
     {
         ClearPlayer();
         playerCoordinates = playerCoordinates with { X = playerCoordinates.X - 1 };
-        if (!BannedCoordinates.Contains(playerCoordinates))
-        {
-            RenderPlayer();
-        }
-        else
+        if (obstacleCollisionIsPossible(bannedCoordinates, playerCoordinates))
         {
             playerCoordinates = playerCoordinates with { X = playerCoordinates.X + 1 };
             RenderPlayer();
         }
+        else RenderPlayer();
     }
 
     pressedKey = Console.ReadKey(intercept: true);
 }
 
+bool obstacleCollisionIsPossible(HashSet<Coordinates> obstacleCoords, Coordinates playerCoords)
+{
+    if (obstacleCoords.Contains(playerCoords))
+    {
+        return true;
+    }
+    return false;
+}
 void ClearPlayer()
 {
     Console.SetCursorPosition(playerCoordinates.X, playerCoordinates.Y);


### PR DESCRIPTION
Made a new HashSet called "BannedCoordinates" that will store the positions of the obstacles. In the random object position generator, all new generated coordinates are saved in the HashSet. The movement system has been updated to block the collision between the player and the obstacles by replacing the simple "RenderPlayer" with a position checker.